### PR TITLE
Clone: don't apply patch to Clone::Choose etc.

### DIFF
--- a/prefs/Clone.yml
+++ b/prefs/Clone.yml
@@ -1,7 +1,7 @@
 ---
 comment: cperl deprecated the ' pkg seperator
 match:
-  distribution: "Clone-"
+  distribution: "Clone-[0-9]"
   perlconfig:
     usecperl: "define"
     version: "^5\.2[5-8]"


### PR DESCRIPTION
This patch changes the regular expression in the YAML file from "Clone-" to "Clone-[0-9]" so that the patch isn't applied to distributions like Clone-Choose.

Clone-Choose is used by Hash::Merge, which in turn is used by SQL::Abstract, Mojo::Pg and Mojo::mysql.

I'll send an another patch for Clone-PP.