### PR TITLE
Clone-PP: strict hashpairs and patch from Clone

### DIFF
--- a/prefs/Clone-PP.yml
+++ b/prefs/Clone-PP.yml
@@ -1,0 +1,9 @@
+---
+comment: "cperl patches: strict hashpairs"
+match:
+  distribution: "Clone-PP-1\.07"
+  perlconfig:
+    usecperl: "define"
+    version: "^5\.2[78]"
+patches:
+  - "RURBAN/patches/Clone-PP-1.07-hashpairs.patch"

--- a/prefs/Clone-PP.yml
+++ b/prefs/Clone-PP.yml
@@ -1,4 +1,13 @@
 ---
+comment: cperl deprecated the ' pkg seperator
+match:
+  distribution: "Clone-PP-1\.07"
+  perlconfig:
+    usecperl: "define"
+    version: "^5\.2[5-8]"
+patches:
+  - "RURBAN/patches/Clone-0.38-cperl525.patch"
+---
 comment: "cperl patches: strict hashpairs"
 match:
   distribution: "Clone-PP-1\.07"

--- a/sources/authors/id/R/RU/RURBAN/patches/Clone-PP-1.07-hashpairs.patch
+++ b/sources/authors/id/R/RU/RURBAN/patches/Clone-PP-1.07-hashpairs.patch
@@ -1,0 +1,13 @@
+diff -ur Clone-PP-1.07.orig/lib/Clone/PP.pm Clone-PP-1.07/lib/Clone/PP.pm
+--- Clone-PP-1.07.orig/lib/Clone/PP.pm	2017-04-10 22:01:14.000000000 +0200
++++ Clone-PP-1.07/lib/Clone/PP.pm	2017-12-27 18:24:05.539423887 +0100
+@@ -57,7 +57,8 @@
+   if ($ref_type eq 'HASH') {
+     $CloneCache{ $source } = $copy = {};
+     if ( my $tied = tied( %$source ) ) { tie %$copy, ref $tied }
+-    %$copy = map { ! ref($_) ? $_ : clone($_, $depth) } %$source;
++    my @temp = map { ! ref($_) ? $_ : clone($_, $depth) } %$source;
++    %$copy = @temp;
+   } elsif ($ref_type eq 'ARRAY') {
+     $CloneCache{ $source } = $copy = [];
+     if ( my $tied = tied( @$source ) ) { tie @$copy, ref $tied }


### PR DESCRIPTION
This pull request applies a patch for Clone to Clone-PP as well.
Another patch makes Clone-PP work with strict hashpairs.

Clone::PP is a dependency of Data::Printer and optionally used by Clone::Choose.